### PR TITLE
mark has sealed concrete value object types

### DIFF
--- a/src/Nox.Types/Types/Email/Email.cs
+++ b/src/Nox.Types/Types/Email/Email.cs
@@ -11,7 +11,7 @@ namespace Nox.Types;
 /// <summary>
 /// Represents a Nox <see cref="Email"/> type and value object. 
 /// </summary>
-public class Email : ValueObject<string, Email>
+public sealed class Email : ValueObject<string, Email>
 {
     private static readonly Regex _emailRegex = new(@"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$", RegexOptions.Compiled, new TimeSpan(0, 0, 1));
 

--- a/src/Nox.Types/Types/LatLong/LatLong.cs
+++ b/src/Nox.Types/Types/LatLong/LatLong.cs
@@ -1,15 +1,12 @@
-﻿
-using FluentValidation;
-using FluentValidation.Results;
+﻿using FluentValidation.Results;
 using System;
-using System.Globalization;
 
 namespace Nox.Types;
 
 /// <summary>
 /// Represents a Nox <see cref="LatLong"/> type and value object. 
 /// </summary>
-public class LatLong : ValueObject<(double Latitude, double Longitude), LatLong>
+public sealed class LatLong : ValueObject<(double Latitude, double Longitude), LatLong>
 {
     public LatLong() { Value = (Latitude: 0, Longitude: 0); } // Null Island
 

--- a/src/Nox.Types/Types/Number/Number.cs
+++ b/src/Nox.Types/Types/Number/Number.cs
@@ -1,17 +1,15 @@
-﻿
-using FluentValidation;
+﻿using FluentValidation;
 using FluentValidation.Results;
 using System;
-using System.Globalization;
 
 namespace Nox.Types;
 
 /// <summary>
 /// Represents a Nox <see cref="Number"/> type and value object. 
 /// </summary>
-public class Number : ValueObject<decimal, Number>
+public sealed class Number : ValueObject<decimal, Number>
 {
-    protected NumberTypeOptions _numberTypeOptions = new();
+    private NumberTypeOptions _numberTypeOptions = new();
 
     public Number() { Value = 0; }
 

--- a/src/Nox.Types/Types/Text/Text.cs
+++ b/src/Nox.Types/Types/Text/Text.cs
@@ -1,5 +1,4 @@
-﻿
-using FluentValidation;
+﻿using FluentValidation;
 using FluentValidation.Results;
 using System;
 using System.Linq;
@@ -9,9 +8,9 @@ namespace Nox.Types;
 /// <summary>
 /// Represents a Nox <see cref="Text"/> type and value object. 
 /// </summary>
-public class Text : ValueObject<string,Text>
+public sealed class Text : ValueObject<string,Text>
 {
-    protected TextTypeOptions _textTypeOptions = new();
+    private TextTypeOptions _textTypeOptions = new();
 
     public Text() { Value = string.Empty; }
 

--- a/src/Nox.Types/ValueObjectBase/ValueObject.cs
+++ b/src/Nox.Types/ValueObjectBase/ValueObject.cs
@@ -8,7 +8,6 @@ using FluentValidation.Results;
 
 namespace Nox.Types;
 
-[Serializable]
 public abstract class ValueObject<T, TValueObject> : INoxType 
     where TValueObject : ValueObject<T, TValueObject>, new() 
 {

--- a/tests/Nox.Types.Tests/EntityFrameworkTests/Models/Country.cs
+++ b/tests/Nox.Types.Tests/EntityFrameworkTests/Models/Country.cs
@@ -3,7 +3,7 @@ namespace Nox.Types.Tests.EntityFrameworkTests;
 
 public class CountryId : ValueObject<int, CountryId> { }
 
-public class Country
+public sealed class Country
 {
     public CountryId Id { get; set; } = null!;
     public Text Name { get; set; } = null!;

--- a/tests/Nox.Types.Tests/NoxLatLongTests.cs
+++ b/tests/Nox.Types.Tests/NoxLatLongTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentValidation;
+﻿using System.Globalization;
+using FluentValidation;
 
 namespace Nox.Types.Tests;
 
@@ -62,12 +63,18 @@ public class NoxLatLongTests
         Assert.NotEqual(coords1, coords2);
     }
 
-    [Fact]
-    public void Nox_LatLong_ToString_ReturnsString()
+    [Theory]
+    [InlineData("en-us","46.948090 7.447440")]
+    [InlineData("pt-PT","46,948090 7,447440")]
+    public void Nox_LatLong_ToString_ReturnsString(string culture, string expectedResult)
     {
-        var coords = LatLong.From(46.94809, 7.44744);
+        void Test()
+        {
+            var coords = LatLong.From(46.94809, 7.44744);
+            Assert.Equal(expectedResult, coords.ToString());
+        }
 
-        Assert.Equal("46.948090 7.447440", coords.ToString());
+        TestUtility.RunInCulture(Test,culture);
     }
 
     [Fact]

--- a/tests/Nox.Types.Tests/NoxNumberTests.cs
+++ b/tests/Nox.Types.Tests/NoxNumberTests.cs
@@ -58,13 +58,18 @@ public class NoxNumberTests
     [Fact]
     public void Nox_Number_ToString_Returns_Value()
     {
-        var testNumber = 3.14m;
+        void Test()
+        {
+            var testNumber = 3.14m;
 
-        var number = Number.From(testNumber);
+            var number = Number.From(testNumber);
 
-        var numberAsString = number.ToString();
+            var numberAsString = number.ToString();
 
-        Assert.Equal("3.14", numberAsString);
+            Assert.Equal("3.14", numberAsString);
+        }
+
+        TestUtility.RunInInvariantCulture(Test);
     }
 
     [Fact]

--- a/tests/Nox.Types.Tests/TestUtility.cs
+++ b/tests/Nox.Types.Tests/TestUtility.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+
+namespace Nox.Types.Tests;
+
+public static class TestUtility
+{
+    internal static void RunInCulture(Action action, string culture)
+    {
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+            action();
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
+    }
+
+    internal static void RunInInvariantCulture(Action action)
+    {
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            action();
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
+    }
+}


### PR DESCRIPTION
remove [Serializable] from ValueObject
make all concrete implementations of ValueObject sealed, so they can not be inherited
refactor some tests to not fail when running in multiple cultures (we need to review tests that are using tostring that is culture dependent)
