### PR TITLE
update LatLong type ToString() to be culture independent

### DIFF
--- a/src/Nox.Types/Types/LatLong/LatLong.cs
+++ b/src/Nox.Types/Types/LatLong/LatLong.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace Nox.Types;
 
@@ -39,7 +40,8 @@ public sealed class LatLong : ValueObject<(double Latitude, double Longitude), L
 
     public override string ToString()
     {
-        return $"{Value.Latitude:0.000000} {Value.Longitude:0.000000}";
+
+        return $"{Value.Latitude.ToString("0.000000", CultureInfo.InvariantCulture)} {Value.Longitude.ToString("0.000000", CultureInfo.InvariantCulture)}";
     }
 
     public string ToString(string format)

--- a/tests/Nox.Types.Tests/Types/LatLong/LatLongTests.cs
+++ b/tests/Nox.Types.Tests/Types/LatLong/LatLongTests.cs
@@ -1,11 +1,12 @@
-﻿namespace Nox.Types.Tests;
+﻿// ReSharper disable once CheckNamespace
+namespace Nox.Types.Tests.Types;
 
-public class NoxLatLongTests
+public class LatLongTests
 {
     [Fact]
     public void Nox_LatLong_Constructor_ReturnsSameValue()
     {
-        var coords = LatLong.From(46.94809, 7.44744);
+        var coords = Nox.Types.LatLong.From(46.94809, 7.44744);
 
         Assert.Equal((46.94809, 7.44744), coords.Value);
     }
@@ -14,7 +15,7 @@ public class NoxLatLongTests
     public void Nox_LatLong_Constructor_WithOutOfRangeLatitude_ThrowsValidationException()
     {
         var exception = Assert.Throws<TypeValidationException>(() => _ =
-          LatLong.From(100, 0)
+          Nox.Types.LatLong.From(100, 0)
         );
 
         Assert.Equal("Could not create a Nox LatLong type with latitude 100 as it is not in the range -90 to 90 degrees.", exception.Errors.First().ErrorMessage);
@@ -24,7 +25,7 @@ public class NoxLatLongTests
     public void Nox_LatLong_Constructor_WithOutOfRangeLongitude_ThrowsValidationException()
     {
         var exception = Assert.Throws<TypeValidationException>(() => _ =
-          LatLong.From(0, 200)
+          Nox.Types.LatLong.From(0, 200)
         );
 
         Assert.Equal("Could not create a Nox LatLong type with longitude 200 as it is not in the range -180 to 180 degrees.", exception.Errors.First().ErrorMessage);
@@ -33,9 +34,9 @@ public class NoxLatLongTests
     [Fact]
     public void Nox_LatLong_Equality_Tests()
     {
-        var coords1 = LatLong.From(46.94809, 7.44744);
+        var coords1 = Nox.Types.LatLong.From(46.94809, 7.44744);
 
-        var coords2 = LatLong.From((Latitude: 46.94809, Longitude: 7.44744));
+        var coords2 = Nox.Types.LatLong.From((Latitude: 46.94809, Longitude: 7.44744));
 
         Assert.Equal(coords1, coords2);
     }
@@ -43,9 +44,9 @@ public class NoxLatLongTests
     [Fact]
     public void Nox_LatLong_Equality_WithDifferentContructor_Tests()
     {
-        var coords1 = LatLong.From(46.94809, 7.44744);
+        var coords1 = Nox.Types.LatLong.From(46.94809, 7.44744);
 
-        var coords2 = LatLong.From((46.94809, 7.44744));
+        var coords2 = Nox.Types.LatLong.From((46.94809, 7.44744));
 
         Assert.Equal(coords1, coords2);
     }
@@ -53,21 +54,21 @@ public class NoxLatLongTests
     [Fact]
     public void Nox_LatLong_NotEqual_Tests()
     {
-        var coords1 = LatLong.From(46.94809, 7.44744);
+        var coords1 = Nox.Types.LatLong.From(46.94809, 7.44744);
 
-        var coords2 = LatLong.From(46.204391, 6.143158);
+        var coords2 = Nox.Types.LatLong.From(46.204391, 6.143158);
 
         Assert.NotEqual(coords1, coords2);
     }
 
     [Theory]
     [InlineData("en-us","46.948090 7.447440")]
-    [InlineData("pt-PT","46,948090 7,447440")]
-    public void Nox_LatLong_ToString_ReturnsString(string culture, string expectedResult)
+    [InlineData("pt-PT","46.948090 7.447440")]
+    public void ToString_IsCultureIndependent(string culture, string expectedResult)
     {
         void Test()
         {
-            var coords = LatLong.From(46.94809, 7.44744);
+            var coords = Nox.Types.LatLong.From(46.94809, 7.44744);
             Assert.Equal(expectedResult, coords.ToString());
         }
 
@@ -77,7 +78,7 @@ public class NoxLatLongTests
     [Fact]
     public void Nox_LatLong_ToString_DMS_ReturnsString()
     {
-        var coords = LatLong.From(46.94809, 7.44744);
+        var coords = Nox.Types.LatLong.From(46.94809, 7.44744);
 
         var str = coords.ToString("dms");
 


### PR DESCRIPTION
Move LatLongTests class to the same folder structure and namespace as LatLongType issue #26